### PR TITLE
solve the issue that post json parameters lost

### DIFF
--- a/src/shims/serverless-handler.php
+++ b/src/shims/serverless-handler.php
@@ -1,7 +1,7 @@
 <?php
 
 define('TEXT_REG', '#\.html.*|\.js.*|\.css.*|\.html.*#');
-define('BINARY_REG', '#\.gif.*|\.jpg.*|\.png.*|\.jepg.*|\.swf.*|\.bmp.*|\.ico.*#');
+define('BINARY_REG', '#\.ttf.*|\.woff.*|\.gif.*|\.jpg.*|\.png.*|\.jepg.*|\.swf.*|\.bmp.*|\.ico.*#');
 
 /**
  * handler static files

--- a/src/shims/serverless-handler.php
+++ b/src/shims/serverless-handler.php
@@ -53,15 +53,24 @@ function handler($event, $context)
 
     $_GET = $event->queryString ?? [];
     $_GET = json_decode(json_encode($_GET), true);
-
+	
+	$_SERVER['REQUEST_METHOD'] = $event->httpMethod;
+	
     if(!empty($event->body)) {
-        $_POSTbody = explode("&", $event->body);
-        foreach ($_POSTbody as $postvalues) {
-            $tmp=explode("=", $postvalues);
-            $_POST[$tmp[0]] = $tmp[1];
-        }
+		$jsonobj = json_decode($event->body, true);
+		if (is_array($jsonobj) && !empty($jsonobj)) {
+			foreach ($jsonobj as $k => $v) {
+				$_POST[$k] = $v;
+			}
+		} else {
+			$_POSTbody = explode("&", $event->body);		
+			foreach ($_POSTbody as $postvalues) {
+				$tmp=explode("=", $postvalues);
+				$_POST[$tmp[0]] = $tmp[1];
+			}
+		}
     }
-
+	
     $app = new \think\App();
     // set runtime path to in /tmp, because only /tmp is writable for cloud
     $app->setRuntimePath('/tmp/runtime' . DIRECTORY_SEPARATOR);


### PR DESCRIPTION
1, the json parameter in post didn't pass correctly.
   Solved by add 
`
$jsonobj = json_decode($event->body, true);
if (is_array($jsonobj) && !empty($jsonobj)) {
    foreach ($jsonobj as $k => $v) {
        $_POST[$k] = $v;
    }
}
`

2, Request::param() parameters had no value

in think\Request.php, the method
`public function method(bool $origin = false): string` 
checks the value of server('REQUEST_METHOD') to decide the http method, but the SCF environment, the value is empty.

