### PR TITLE
修正post参数问题：调用input('param.')获取参数时发现参数值中有前一次request的参数内容 

### DIFF
--- a/src/_shims/sl_handler.php
+++ b/src/_shims/sl_handler.php
@@ -56,7 +56,7 @@ function handler($event, $context)
 
     $_SERVER['REQUEST_METHOD'] = $event->httpMethod;
 	
-	$_POST = array();
+    $_POST = array();
 	
     if(!empty($event->body)) {
       $jsonobj = json_decode($event->body, true);


### PR DESCRIPTION
修正post参数问题：
调用input('param.')获取参数时发现参数值中有前一次request的参数内容 