### PR TITLE
完善多应用

### DIFF
--- a/src/_shims/sl_handler.php
+++ b/src/_shims/sl_handler.php
@@ -89,15 +89,14 @@ function handler($event, $context)
     // Check if it is running in multi-app
     $isMultiApp = isMultiApp($app);
     if($isMultiApp) {
-        $appName = getAppName("/".$path);
+        $appName = getAppName($path);
         if($appName == '') {
             // if app name not included in the request path,
             // find the default one defined in config/app.php
             include_once $app->getThinkPath() . 'helper.php'; // include helper for env()
-            $appConfig = require __DIR__ . '/config/app.php';
-            $appName = isset($appConfig['default_app']) ? $appConfig['default_app'] : 'index';
+            $appName = $app->config->get('app.default_app') ?: 'index';
         } else {
-            $request->setPathinfo(substr($path, strlen($appName)));
+            $request->setPathinfo(strpos($path, '/') ? ltrim(strstr($path, '/'), '/') : '');
         }
         $response = $http->name($appName)->run($request);
     } else {
@@ -127,16 +126,12 @@ function isMultiApp() : bool
 
 function getAppName($path)
 {
-    $strpos = strpos($path, '/');
-    if($strpos || $strpos == 0) {
-        $appname = substr($path, $strpos + 1, strlen($path));
-        // check if the folder exists
-        $appPath = __DIR__ . "/app/" . $appname;
-        if(is_dir($appPath)) {
-            return $appname;
-        }
+    $appname = current(explode('/', $path));
+    // check if the folder exists
+    $appPath = __DIR__ . "/app/" . $appname;
+    if(is_dir($appPath)) {
+        return $appname;
     }
 
     return '';
-
 }


### PR DESCRIPTION
在某个应用下定义对应的路由配置，现有的版本支持不太完善。

`app/admin/route.php`

```php
<?php
use think\facade\Route;

Route::get('member/:name', function ($name) {
    return json([
        'method' => request()->method(),
        'action' => 'GET User => ' . $name,
        'params' => request()->get(),
    ]);
});
```
`GET www.domain.com/admin/member/sls`

结果是访问到 `index` 应用下。
